### PR TITLE
Add wallarm_version param && update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ Wallarm's Framework for Automated Security Testing (FAST) is a purpose-built too
 
 To pack this orb use next command:
 ```sh
-circleci config pack src/ >> fast-orb.yaml
+circleci config pack src/ > fast-orb.yaml
 ```

--- a/src/commands/run_security_tests.yaml
+++ b/src/commands/run_security_tests.yaml
@@ -63,6 +63,12 @@ parameters:
     description: >
       Wallarm FAST port.
 
+  wallarm_version:
+    type: string
+    default: 'latest'
+    description: |
+      Wallarm FAST version
+
 steps:
   - run:
       name: Setup fast.env file
@@ -83,4 +89,4 @@ steps:
   - run: 
       name: Run security tests.
       command: |
-        docker run --name fast --env-file=fast.env -p <<parameters.wallarm_fast_port>>:8080 wallarm/fast
+        docker run --name fast --env-file=fast.env -p <<parameters.wallarm_fast_port>>:8080 wallarm/fast:<<parameters.wallarm_version>>

--- a/src/examples/fast-example-rails.yaml
+++ b/src/examples/fast-example-rails.yaml
@@ -1,7 +1,7 @@
 description: |
   Example using Wallarm's FAST to run tests against simple Ruby on Rails application.
   In this example parameter app_port is used.
-  Taken from https://github.com/wallarm/fast-examples-rails.
+  Taken from https://github.com/wallarm/fast-example-rails.
 
 usage:
   version: 2.1
@@ -18,14 +18,9 @@ usage:
         - checkout
 
         - run:
-            name: Build docker
-            command: |
-              docker build -t app-test .
-
-        - run:
             name: Run application
             command: |
-              docker run -d --name app-test -p 3000:3000 app-test
+              docker run -d --name app-test -p 3000:3000 wallarm/fast-example-rails
 
         - fast/run_security_tests:
             app_port: "3000"


### PR DESCRIPTION
orb version will be 1.1.0

`wallarm_version` was tested with three scenarios:
- default (latest)
- invalid value
- valid older version (v1.80.0)